### PR TITLE
Enable Edge DB for Ruby

### DIFF
--- a/examples/sinatra/Gemfile.lock
+++ b/examples/sinatra/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    devcycle-ruby-server-sdk (1.0.0)
+    devcycle-ruby-server-sdk (1.2.0)
       typhoeus (~> 1.0, >= 1.0.1)
 
 GEM

--- a/examples/sinatra/app.rb
+++ b/examples/sinatra/app.rb
@@ -12,6 +12,7 @@ DevCycle.configure do |config|
     # Configure API key authorization: bearerAuth
     config.api_key['bearerAuth'] = token
     # config.debugging = true
+    config.enable_edge_db = false
 end
 
 api_instance = DevCycle::DVCClient.new

--- a/lib/devcycle-ruby-server-sdk/api_client.rb
+++ b/lib/devcycle-ruby-server-sdk/api_client.rb
@@ -94,6 +94,10 @@ module DevCycle
       query_params = opts[:query_params] || {}
       form_params = opts[:form_params] || {}
 
+      if @config.enable_edge_db
+        query_params.store("enableEdgeDB", true)
+      end
+
       update_params_for_auth! header_params, query_params, opts[:auth_names]
 
       # set ssl_verifyhosts option based on @config.verify_ssl_host (true/false)

--- a/lib/devcycle-ruby-server-sdk/configuration.rb
+++ b/lib/devcycle-ruby-server-sdk/configuration.rb
@@ -137,6 +137,10 @@ module DevCycle
 
     attr_accessor :force_ending_format
 
+   # Define if EdgeDB is Enabled (Boolean)
+   # Default to false
+   attr_accessor :enable_edge_db
+
     def initialize
       @scheme = 'https'
       @host = 'bucketing-api.devcycle.com'
@@ -158,6 +162,7 @@ module DevCycle
       @inject_format = false
       @force_ending_format = false
       @logger = defined?(Rails) ? Rails.logger : Logger.new(STDOUT)
+      @enable_edge_db = false
 
       yield(self) if block_given?
     end
@@ -272,6 +277,12 @@ module DevCycle
       end
 
       url
+    end
+
+    def enable_edge_db=(enable_edge_db = false)
+      if(enable_edge_db)
+        @enable_edge_db = true
+      end
     end
 
   end

--- a/lib/devcycle-ruby-server-sdk/version.rb
+++ b/lib/devcycle-ruby-server-sdk/version.rb
@@ -11,5 +11,5 @@ OpenAPI Generator version: 5.3.0
 =end
 
 module DevCycle
-  VERSION = '1.1.1'
+  VERSION = '1.2.0'
 end

--- a/spec/api_client_spec.rb
+++ b/spec/api_client_spec.rb
@@ -49,6 +49,23 @@ describe DevCycle::ApiClient do
         end
       end
     end
+
+    context 'Enabled Edge DB' do
+      it 'defaults the enable_edge_db value to false when no value is provided' do
+        DevCycle.configure { }
+        expect(DevCycle::Configuration.default.enable_edge_db).to eq(false)
+      end
+      
+      it 'sets the enable_edge_db value to false when false is provided' do
+        DevCycle.configure { |c| c.enable_edge_db = false }
+        expect(DevCycle::Configuration.default.enable_edge_db).to eq(false)
+      end
+      
+      it 'sets the enable_edge_db value to true when true is provided' do
+        DevCycle.configure { |c| c.enable_edge_db = true }
+        expect(DevCycle::Configuration.default.enable_edge_db).to eq(true)
+      end
+    end
   end
 
   describe 'params_encoding in #build_request' do


### PR DESCRIPTION
- add `enable_edge_db` param to configuration (defaults to false)
- check if param is true to add a query param to all outbound requests to DevCycle Bucketing API
- add unit tests to check configuration is defaulting, accepting and setting the new enable_edge_db values correctly
- bump version for release to `1.2.0`