### PR TITLE
add track method for local sdk

### DIFF
--- a/examples/sinatra/testing.rb
+++ b/examples/sinatra/testing.rb
@@ -2,13 +2,19 @@ require 'devcycle-ruby-server-sdk'
 
 options = DevCycle::DVCOptions.new(enable_cloud_bucketing: false, event_flush_interval_ms: 1000, config_polling_interval_ms: 1000)
 test_user = DevCycle::UserData.new({ user_id: "test" })
+test_event = DevCycle::Event.new({
+                                    :'type' => :'randomEval',
+                                    :'target' => :'custom target'
+                                  })
 dvc_client = DevCycle::DVCClient.new("dvc_server_token_hash", options) do |error|
   if error.nil?
     sleep 5
+    puts "\n"
     puts 'DVC Client initialized'
     puts dvc_client.variable(test_user, 'test', false)
     puts dvc_client.all_variables(test_user)
     puts dvc_client.all_features(test_user)
+    dvc_client.track(test_user, test_event)
   else
     puts error
   end
@@ -16,6 +22,7 @@ end
 puts dvc_client.variable(test_user, 'test', false)
 puts dvc_client.all_variables(test_user)
 puts dvc_client.all_features(test_user)
+dvc_client.track(test_user, test_event)
 
 sleep 15
 # test_event = DevCycle::Event.new({

--- a/lib/devcycle-ruby-server-sdk.rb
+++ b/lib/devcycle-ruby-server-sdk.rb
@@ -15,7 +15,8 @@ require 'devcycle-ruby-server-sdk/api_client'
 require 'devcycle-ruby-server-sdk/api_error'
 require 'devcycle-ruby-server-sdk/version'
 require 'devcycle-ruby-server-sdk/configuration'
-require 'devcycle-ruby-server-sdk/event_queue'
+require 'devcycle-ruby-server-sdk/localbucketing/event_queue'
+require 'devcycle-ruby-server-sdk/localbucketing/event_types'
 
 # Models
 require 'devcycle-ruby-server-sdk/models/error_response'
@@ -33,6 +34,8 @@ require 'devcycle-ruby-server-sdk/localbucketing/dvc_options'
 require 'devcycle-ruby-server-sdk/localbucketing/local_bucketing'
 require 'devcycle-ruby-server-sdk/localbucketing/platform_data'
 require 'devcycle-ruby-server-sdk/localbucketing/bucketed_user_config'
+require 'devcycle-ruby-server-sdk/localbucketing/event_queue'
+require 'devcycle-ruby-server-sdk/localbucketing/event_types'
 
 module DevCycle
   class << self

--- a/lib/devcycle-ruby-server-sdk/localbucketing/bucketed_user_config.rb
+++ b/lib/devcycle-ruby-server-sdk/localbucketing/bucketed_user_config.rb
@@ -1,5 +1,4 @@
 module DevCycle
-
   class BucketedUserConfig
     attr_accessor :project
     attr_accessor :environment
@@ -19,5 +18,4 @@ module DevCycle
       @known_variable_keys = known_variable_keys
     end
   end
-
 end

--- a/lib/devcycle-ruby-server-sdk/localbucketing/event_queue.rb
+++ b/lib/devcycle-ruby-server-sdk/localbucketing/event_queue.rb
@@ -76,7 +76,7 @@ module DevCycle
       nil
     end
 
-    sig { params(event: Event, bucketed_config: BucketedUserConfig).returns(NilClass) }
+    sig { params(event: Event, bucketed_config: T.nilable(BucketedUserConfig)).returns(NilClass) }
     def queue_aggregate_event(event, bucketed_config)
       if max_event_queue_size_reached?
         @logger.warn("Max event queue size reached, dropping event: #{event}")

--- a/lib/devcycle-ruby-server-sdk/localbucketing/event_types.rb
+++ b/lib/devcycle-ruby-server-sdk/localbucketing/event_types.rb
@@ -1,0 +1,8 @@
+module DevCycle
+  EventTypes = {
+    variable_evaluated: 'variableEvaluated',
+    agg_variable_evaluated: 'aggVariableEvaluated',
+    variable_defaulted: 'variableDefaulted',
+    agg_variable_defaulted: 'aggVariableDefaulted'
+  }.freeze
+end

--- a/lib/devcycle-ruby-server-sdk/localbucketing/local_bucketing.rb
+++ b/lib/devcycle-ruby-server-sdk/localbucketing/local_bucketing.rb
@@ -147,10 +147,16 @@ module DevCycle
       @@instance.invoke("queueEvent", sdkkey_addr, user_addr, event_addr)
     end
 
-    sig { params(event: Event, bucketeduser: BucketedUserConfig).returns(NilClass) }
+    sig { params(event: Event, bucketeduser: T.nilable(BucketedUserConfig)).returns(NilClass) }
     def queue_aggregate_event(event, bucketeduser)
       sdkkey_addr = malloc_asc_string(@sdkkey)
-      varmap_addr = malloc_asc_string(Oj.dump(bucketeduser.variable_variation_map))
+      variable_variation_map =
+      if !bucketeduser.nil?
+        bucketeduser.variable_variation_map 
+      else
+        {}
+      end
+      varmap_addr = malloc_asc_string(Oj.dump(variable_variation_map))
       event_addr = malloc_asc_string(Oj.dump(event))
       @@stack_tracer = lambda { |message| raise message }
       @@instance.invoke("queueAggregateEvent", sdkkey_addr, event_addr, varmap_addr)

--- a/spec/api/devcycle_api_spec.rb
+++ b/spec/api/devcycle_api_spec.rb
@@ -93,26 +93,4 @@ describe 'DVCClient' do
     end
   end
 
-  # unit tests for post_events
-  # Post events to DevCycle for user
-  # @param user_data_and_events_body 
-  # @param [Hash] opts the optional parameters
-  # @return [InlineResponse201]
-  describe 'post_events test' do
-    it 'should work' do
-      event_data = DevCycle::Event.new({        
-        type: "my-event",
-        target: "some_event_target",
-        value: 12,
-        metaData: {
-            myKey: "my-value"
-        }
-    })
-
-    result = @api_instance.track(@user_data, event_data)
-
-    expect(result.message).to eq "Successfully received 1 events."
-    end
-  end
-
 end


### PR DESCRIPTION
# Changes
* add track method for local bucketing sdk
* renamed the `initialized?` method to `local_bucketing_initialized?` for clarity
* `variable` method now queues aggregate events for evaluated and defaulted cases