### PR TITLE
fix: return nil on client close

### DIFF
--- a/lib/devcycle-ruby-server-sdk/api/devcycle_api.rb
+++ b/lib/devcycle-ruby-server-sdk/api/devcycle_api.rb
@@ -56,6 +56,7 @@ module DevCycle
 
       @event_queue.close
       @logger.info("Closed DevCycle Client.")
+      nil
     end
 
     def set_client_custom_data(customdata)


### PR DESCRIPTION
# Changes
* return `nil` on client close