### PR TITLE
fix: set run_now to false for config polling and event flush timer task

### DIFF
--- a/lib/devcycle-ruby-server-sdk/localbucketing/config_manager.rb
+++ b/lib/devcycle-ruby-server-sdk/localbucketing/config_manager.rb
@@ -23,8 +23,7 @@ module DevCycle
 
       @config_poller = Concurrent::TimerTask.new(
         {
-          execution_interval: @local_bucketing.options.config_polling_interval_ms.fdiv(1000),
-          run_now: true
+          execution_interval: @local_bucketing.options.config_polling_interval_ms.fdiv(1000)
         }) do |task|
         fetch_config(false, task)
       end


### PR DESCRIPTION
# Changes
* set `run_now` to false for config polling and flush timer
* remove timer task observer that was used for testing
* set `Content-Type` for event requests to `application/json` - the default is `application/x-www-form-urlencoded`