### PR TITLE
fix: change directive of pack to use c for reading and writing

### DIFF
--- a/lib/devcycle-ruby-server-sdk/localbucketing/local_bucketing.rb
+++ b/lib/devcycle-ruby-server-sdk/localbucketing/local_bucketing.rb
@@ -272,7 +272,7 @@ module DevCycle
       i = 0
       while i < byte_len
         @@stack_tracer = @@stack_tracer_raise
-        @@memory.write(start_addr + (i * 2), [utf8_bytes[i]].pack('U'))
+        @@memory.write(start_addr + (i * 2), [utf8_bytes[i]].pack('c'))
         i += 1
       end
       start_addr


### PR DESCRIPTION
# Summary

When writing to memory the byte representation, use the same directive `c*` as the one used in the `read_asc_string` method.