### PR TITLE
fix: NoMemoryError caused by Oj.dump

### DIFF
--- a/lib/devcycle-ruby-server-sdk/localbucketing/config_manager.rb
+++ b/lib/devcycle-ruby-server-sdk/localbucketing/config_manager.rb
@@ -74,11 +74,16 @@ module DevCycle
           stop_polling
           @logger.error("Failed to download DevCycle config; Invalid SDK Key.")
           break
+        when 404
+          stop_polling
+          @logger.error("Failed to download DevCycle config; Config not found.")
+          break
         when 500...599
           @logger.error("Failed to download DevCycle config. Status: #{resp.code}")
         else
-          stop_polling
-          @logger.error("Unexpected response code - DevCycle Response: #{Oj.dump(resp)}")
+          @logger.error("Unexpected response from DevCycle CDN")
+          @logger.error("Response code: #{resp.code}")
+          @logger.error("Response body: #{resp.body}")
           break
         end
       end


### PR DESCRIPTION
# Changes
* remove call to `Oj.dump` on entire response object
* fix polling logic
   * don't stop polling when there's an unexpected response
   * stop polling when there's a 404 response