### PR TITLE
chore: upgrade wasmtime to latest (39.0.1) to work with ruby 3.4.7

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -15,13 +15,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: [ '3.2.0', '3.3.0' ]
+        ruby-version: [ '3.2.0', '3.3.0', '3.4.1' ]
     env:
       DEVCYCLE_SERVER_SDK_KEY: dvc_server_token_hash
     steps:
       - uses: actions/checkout@v4
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1.187.0
+        uses: ruby/setup-ruby@v1.264.0
         with:
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically

--- a/devcycle-ruby-server-sdk.gemspec
+++ b/devcycle-ruby-server-sdk.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 3.2"
 
   s.add_runtime_dependency 'typhoeus', '~> 1.0', '>= 1.0.1'
-  s.add_runtime_dependency 'wasmtime', '20.0.2'
+  s.add_runtime_dependency 'wasmtime', '39.0.1'
   s.add_runtime_dependency 'concurrent-ruby', '~> 1.2.0'
   s.add_runtime_dependency 'sorbet-runtime', '>= 0.5.11481'
   s.add_runtime_dependency 'oj', '~> 3.0'

--- a/devcycle-ruby-server-sdk.gemspec
+++ b/devcycle-ruby-server-sdk.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'oj', '~> 3.0'
   s.add_runtime_dependency 'google-protobuf', '~> 3.22'
   s.add_runtime_dependency 'ld-eventsource', '~> 2.2.3'
-  s.add_runtime_dependency 'openfeature-sdk', '~> 0.4.0'
+  s.add_runtime_dependency 'openfeature-sdk', '~> 0.4.1'
 
   s.add_development_dependency 'rspec', '~> 3.6', '>= 3.6.0'
 

--- a/lib/devcycle-ruby-server-sdk/api/dev_cycle_provider.rb
+++ b/lib/devcycle-ruby-server-sdk/api/dev_cycle_provider.rb
@@ -32,7 +32,16 @@ module DevCycle
     end
 
     def fetch_integer_value(flag_key:, default_value:, evaluation_context: nil)
-      @client.variable(Provider.user_from_openfeature_context(evaluation_context), flag_key, default_value)
+      variable = @client.variable(Provider.user_from_openfeature_context(evaluation_context), flag_key, default_value)
+
+      Variable.new(
+        key: variable.key,
+        type: variable.type,
+        value: variable.value.to_i,
+        defaultValue: variable.defaultValue,
+        isDefaulted: variable.isDefaulted,
+        eval: variable.eval
+      )
     end
 
     def fetch_float_value(flag_key:, default_value:, evaluation_context: nil)

--- a/lib/devcycle-ruby-server-sdk/localbucketing/local_bucketing.rb
+++ b/lib/devcycle-ruby-server-sdk/localbucketing/local_bucketing.rb
@@ -27,14 +27,14 @@ module DevCycle
     # added to ensure that there is no processes deadlock when compiling wasm before forking
 
     @@wasmmodule = Wasmtime::Module.from_file(@@engine, "#{__dir__}/bucketing-lib.release.wasm")
-    @@wasi_ctx = Wasmtime::WasiCtxBuilder.new
-                                         .inherit_stdout
-                                         .inherit_stderr
-                                         .set_argv(ARGV)
-                                         .set_env(ENV)
-                                         .build
-    @@store = Wasmtime::Store.new(@@engine, wasi_ctx: @@wasi_ctx)
-    @@linker = Wasmtime::Linker.new(@@engine, wasi: true)
+    @@wasi_config = Wasmtime::WasiConfig.new
+                                        .inherit_stdout
+                                        .inherit_stderr
+                                        .set_argv(ARGV)
+                                        .set_env(ENV)
+    @@store = Wasmtime::Store.new(@@engine, wasi_p1_config: @@wasi_config)
+    @@linker = Wasmtime::Linker.new(@@engine)
+    Wasmtime::WASI::P1.add_to_linker_sync(@@linker)
 
     @@linker.func_new("env", "Date.now", [], [:f64]) do |_caller|
       DateTime.now.strftime("%Q").to_i


### PR DESCRIPTION
- chore: updates `wasmtime` to `39.0.1` (Dec 05, 2025 release)
  - update wasm initialization code to work with wasmtime upgdate
- chore: bump `ruby/setup-ruby@v1.264.0` to support up to `ruby 3.4.7` and adds `ruby 3.4.1` to unit test workflow on GH Actions
- fix: updates the `fetch_integer_value` method in the OpenFeature provider to always cast the response to integer and return it
- chore: bumps OpenFeature Ruby to `0.4.1`