### PR TITLE
chore: resolve open dependabot security alerts

### DIFF
--- a/examples/local/Gemfile
+++ b/examples/local/Gemfile
@@ -10,7 +10,7 @@ gem "rails", "~> 7.0.4", ">= 7.0.4.2"
 gem "sprockets-rails"
 
 # Use sqlite3 as the database for Active Record
-gem "sqlite3", "~> 1.4"
+gem "sqlite3", ">= 2.9.5"
 
 # Use the Puma web server [https://github.com/puma/puma]
 gem "puma", "~> 5.0"


### PR DESCRIPTION
## Summary

- Bumped `sqlite3` constraint from `~> 1.4` to `>= 2.9.5` in `examples/local/Gemfile` to resolve low-severity vulnerability (CVE-2026-54619)

## Dependabot Alerts Resolved

| Alert | Package | Severity | Fix |
|-------|---------|----------|-----|
| #8 | `sqlite3` | **low** | Bumped constraint to `>= 2.9.5` in `examples/local/Gemfile` |

## Test plan

- [ ] CI unit tests pass (change is isolated to the example app Gemfile; does not affect SDK tests)